### PR TITLE
[Feat] 문의하기 뷰 완성

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,8 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="..\:/Users/82109/Desktop/and/joint15_29cm/app/src/main/res/font/fontfamily.xml" value="0.20092592592592592" />
+        <entry key="app/src/main/res/layout/activity_read.xml" value="0.3609375" />
+        <entry key="app/src/main/res/layout/inquiry_toolbar.xml" value="0.3705291748046875" />
       </map>
     </option>
   </component>

--- a/app/src/main/res/drawable/stroke_btn_basic.xml
+++ b/app/src/main/res/drawable/stroke_btn_basic.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    >
+
+    <solid android:color="@color/white_29cm"/>
+    <stroke
+        android:width="1dp"
+        android:color="@color/box_grey_29cm"/>
+</shape>

--- a/app/src/main/res/layout/activity_read.xml
+++ b/app/src/main/res/layout/activity_read.xml
@@ -7,6 +7,85 @@
     tools:context=".feature.mino.ReadActivity">
 
     <include
-        layout="@layout/inquiry_toolbar"/>
+        android:id="@+id/include"
+        layout="@layout/inquiry_toolbar" />
 
+    <LinearLayout
+        android:id="@+id/linearLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/app_horizontal_padding"
+        app:layout_constraintTop_toBottomOf="@+id/include">
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_38"
+            android:text="@string/title"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_18_Medium"
+            app:layout_constraintTop_toBottomOf="@+id/include" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_43"
+            android:text="@string/consulting_main"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_12_Regular_Black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:lineHeight="15dp"
+            android:text="@string/consulting_detail"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_11_Regular_Grey"
+            tools:ignore="UnusedAttribute" />
+
+        <Button
+            style="@style/Widget.ConsultingButton.Style_Noto_12_Regular_White"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_consulting" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:text="@string/empty_consulting_list"
+        android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_13_Regular"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@id/tabLayout"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_consulting"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/tabLayout"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2"
+        tools:listitem="@layout/item_consulting_recyclerview" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:paddingBottom="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:tabIndicatorAnimationMode="fade"
+        app:tabIndicatorFullWidth="false"
+        app:tabIndicatorHeight="1dp"
+        app:tabRippleColor="@android:color/transparent"
+        app:tabTextAppearance="@style/Widget.GlobalTextView.Appearance_Neo_20_Bold">
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="1" />
+    </com.google.android.material.tabs.TabLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_read.xml
+++ b/app/src/main/res/layout/activity_read.xml
@@ -6,13 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".feature.mino.ReadActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <include
+        layout="@layout/inquiry_toolbar"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/inquiry_toolbar.xml
+++ b/app/src/main/res/layout/inquiry_toolbar.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.Toolbar
+        android:layout_width="match_parent"
+        android:layout_height="70dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageButton
+                android:id="@+id/btn_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/white"
+                android:src="@drawable/ic_icn_back"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btn_search"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="32dp"
+                android:background="@color/white"
+                android:src="@drawable/ic_icn_search"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/btn_cart" />
+
+            <ImageButton
+                android:id="@+id/btn_cart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="19dp"
+                android:background="@color/white"
+                android:src="@drawable/ic_icn_mycart"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.appcompat.widget.Toolbar>
+</layout>

--- a/app/src/main/res/layout/item_consulting_recyclerview.xml
+++ b/app/src/main/res/layout/item_consulting_recyclerview.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/app_horizontal_padding"
+        android:background="@color/white_29cm"
+        android:paddingTop="14dp"
+        android:paddingBottom="18dp"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_item_day"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_quick_12_Grey3"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/tools_consulting_day" />
+
+        <TextView
+            android:id="@+id/tv_item_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="7dp"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_12_Bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_item_day"
+            tools:text="@string/tools_consulting_title" />
+
+        <TextView
+            android:id="@+id/tv_item_finished"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_quick_11_Grey2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_item_title"
+            tools:text="@string/tools_consulting_finished" />
+
+        <Button
+            style="@style/Widget.DeleteButton.Style_Noto_12_Regular"
+            android:layout_width="70dp"
+            android:layout_height="wrap_content"
+            android:stateListAnimator="@null"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="@string/tools_consulting_delete_btn" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/item_layout_detail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/grey04_29cm"
+        android:orientation="vertical"
+        android:padding="@dimen/app_horizontal_padding"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/constraint">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Q."
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Neo_20_Bold" />
+
+        <TextView
+            android:id="@+id/tv_question"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:lineHeight="24dp"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_12_Regular_Black"
+            tools:text="어쩌구\n 저쩌구"
+            tools:ignore="UnusedAttribute" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            android:text="A."
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Neo_20_Bold" />
+
+        <TextView
+            android:id="@+id/tv_answer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:lineHeight="24dp"
+            android:textAppearance="@style/Widget.GlobalTextView.Appearance_Noto_12_Regular_Black"
+            tools:ignore="UnusedAttribute" />
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="text_noto_18">18sp</dimen>
+    <dimen name="text_noto_15">15sp</dimen>
+    <dimen name="text_noto_13">13sp</dimen>
+    <dimen name="text_noto_12">12sp</dimen>
+    <dimen name="text_noto_11">11sp</dimen>
+    <dimen name="text_neo_20">20sp</dimen>
+    <dimen name="app_horizontal_padding">19dp</dimen>
+    <dimen name="margin_38">38dp</dimen>
+    <dimen name="margin_43">43dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,16 @@
     <string name="app_name">joint15_29cm</string>
 
     <!--문의내용 뷰-->
-    <string name="what">joint15_29cm</string>
+    <string name="title">1:1문의내역</string>
+    <string name="consulting_title">상담시간</string>
+    <string name="consulting_main">평일(월 ~ 금) 10:00~17:00\n(Off-time 12:00 ~ 14:00, 토/일 공휴일 휴무)</string>
+    <string name="consulting_detail">ㆍ 한 번 등록한 상담내용은 수정이 불가능합니다.\nㆍ 향후 멤버쉽 단계별 혜택 및 선정기준은 사전공지 후 변경될 수 있습\n니다.</string>
+    <string name="btn_consulting">1:1문의 쓰기</string>
+    <string name="empty_consulting_list">내역이 없습니다.</string>
+    <string name="tools_consulting_day">2022–05–16</string>
+    <string name="tools_consulting_title">회원제도문의</string>
+    <string name="tools_consulting_finished">No</string>
+    <string name="tools_consulting_delete_btn">삭제</string>
     <!--문의하기 뷰-->
     <string name="whatt">joint15_29cm</string>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Joint15_29cm" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Joint15_29cm" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/black</item>
         <item name="colorPrimaryVariant">@color/black</item>
@@ -38,7 +38,7 @@
         <item name="android:padding">5dp</item>
         <item name="android:layout_marginTop">11dp</item>
         <item name="android:textColor">@color/black02_29cm</item>
-        <item name="android:backgroundTint">@color/white_29cm</item>
+        <item name="android:background">@drawable/stroke_btn_basic</item>
         <item name="android:textAppearance">
             @style/Widget.GlobalTextView.Appearance_Noto_12_Regular_Black
         </item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,8 +10,88 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor" >?attr/colorPrimaryVariant</item>
         <item name="android:includeFontPadding">false</item>
         <!-- Customize your theme here. -->
     </style>
+
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_18_Medium" parent="">
+        <item name="android:textColor">@color/black01_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_18</item>
+        <item name="android:fontFamily">@font/notosanskr_medium</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_15_Bold" parent="">
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_15</item>
+        <item name="android:fontFamily">@font/notosanskr_bold</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_13_Regular" parent="">
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_13</item>
+        <item name="android:fontFamily">@font/notosanskr_regular</item>
+    </style>
+
+    <style name="Widget.DeleteButton.Style_Noto_12_Regular" parent="">
+        <item name="android:padding">5dp</item>
+        <item name="android:layout_marginTop">11dp</item>
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:backgroundTint">@color/white_29cm</item>
+        <item name="android:textAppearance">
+            @style/Widget.GlobalTextView.Appearance_Noto_12_Regular_Black
+        </item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_12_Regular_Black" parent="">
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_12</item>
+        <item name="android:fontFamily">@font/notosanskr_regular</item>
+    </style>
+
+    <style name="Widget.ConsultingButton.Style_Noto_12_Regular_White" parent="">
+        <item name="android:layout_marginTop">11dp</item>
+        <item name="android:background">@color/black02_29cm</item>
+        <item name="android:textAppearance">
+            @style/Widget.ConsultingButton.Appearance_Noto_12_Regular_White
+        </item>
+    </style>
+
+    <style name="Widget.ConsultingButton.Appearance_Noto_12_Regular_White" parent="">
+        <item name="android:textColor">@color/white_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_12</item>
+        <item name="android:fontFamily">@font/notosanskr_regular</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_12_Bold" parent="">
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_12</item>
+        <item name="android:fontFamily">@font/notosanskr_bold</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Noto_11_Regular_Grey" parent="">
+        <item name="android:textColor">@color/grey02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_11</item>
+        <item name="android:fontFamily">@font/notosanskr_regular</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_Neo_20_Bold" parent="">
+        <item name="android:textColor">@color/black02_29cm</item>
+        <item name="android:textSize">@dimen/text_neo_20</item>
+        <item name="android:fontFamily">@font/spoqahansansneo_bold</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_quick_11_Grey2" parent="">
+        <item name="android:textColor">@color/grey02_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_11</item>
+        <item name="android:fontFamily">@font/quicksand_semibold</item>
+    </style>
+
+    <style name="Widget.GlobalTextView.Appearance_quick_12_Grey3" parent="">
+        <item name="android:textColor">@color/grey03_29cm</item>
+        <item name="android:textSize">@dimen/text_noto_12</item>
+        <item name="android:fontFamily">@font/quicksand_semibold</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
### 반복되는 layout 재활용을 위해 appbar는 따로 컴포넌트화 시켜놨습니다.
- 다음과 같이 사용하시면 됩니다. inquiry_toolbar.xml
```xml
    <include
        layout="@layout/inquiry_toolbar"/>
```

### Style 관련
- String
```xml
<!--문의내용 뷰-->
    <string name="title">1:1문의내역</string>
    <string name="consulting_title">상담시간</string>
    <string name="consulting_main">평일(월 ~ 금) 10:00~17:00\n(Off-time 12:00 ~ 14:00, 토/일 공휴일 휴무)</string>
    <string name="consulting_detail">ㆍ 한 번 등록한 상담내용은 수정이 불가능합니다.\nㆍ 향후 멤버쉽 단계별 혜택 및 선정기준은 사전공지 후 변경될 수 있습\n니다.</string>
    <string name="btn_consulting">1:1문의 쓰기</string>
    <string name="empty_consulting_list">내역이 없습니다.</string>
    <string name="tools_consulting_day">2022–05–16</string>
    <string name="tools_consulting_title">회원제도문의</string>
    <string name="tools_consulting_finished">No</string>
    <string name="tools_consulting_delete_btn">삭제</string>
```
- dimens 추가
```xml
<resources>
    <dimen name="text_noto_18">18sp</dimen>
    <dimen name="text_noto_15">15sp</dimen>
    <dimen name="text_noto_13">13sp</dimen>
    <dimen name="text_noto_12">12sp</dimen>
    <dimen name="text_noto_11">11sp</dimen>
    <dimen name="text_neo_20">20sp</dimen>
    <dimen name="app_horizontal_padding">19dp</dimen>
    <dimen name="margin_38">38dp</dimen>
    <dimen name="margin_43">43dp</dimen>
</resources>
```

- theme 추가
폰트별로 textAppearance 지정해놨는데, 더 광범위하게 사용하려면 말 맞추고 하는게 더 나았을 것 같아요..! 이건 길어서 따로 첨부하진 않겠습니다.

### 화면
<img width="250" alt="스크린샷 2022-05-16 오후 9 59 26" src="https://user-images.githubusercontent.com/15981307/168597994-3fb23b56-8427-474d-8f0a-f2f907de6f6f.png">
- visibility 영역 ( Recycler Item )
<img width="331" alt="스크린샷 2022-05-16 오후 10 00 59" src="https://user-images.githubusercontent.com/15981307/168598248-d5ccd06f-218c-47f2-8367-45054392b2d8.png">


### 추가사항
- 하단 페이지를 어떻게 처리할지 애매합니다.
- 일단 Tablayout에 넣어놨는데 깔끔하지 않을 것 같아서 조언을 구하고 싶습니다!